### PR TITLE
[ Fix ]：missing return while URLSession fail , and delete force unwrapped print

### DIFF
--- a/HTTPDNS/Factory.swift
+++ b/HTTPDNS/Factory.swift
@@ -33,20 +33,27 @@ class HTTPDNSBase: HTTPDNSBaseProtocol {
         let urlString = getRequestString(domain)
         guard let url = URL(string: urlString) else {
             print("Error: cannot create URL")
+            callback(nil)
             return
         }
         
         let task = URLSession.shared.dataTask(with: url, completionHandler: {(data, response, error) in
-            print(NSString(data: data!, encoding: String.Encoding.utf8.rawValue)!)
             guard let responseData = data else {
                 print("Error: Didn't receive data")
+                callback(nil)
                 return
             }
             guard error == nil else {
                 print("Error: Calling GET error on " + urlString)
-                print(error!)
+                print(error?.localizedDescription)
+                callback(nil)
                 return
             }
+    
+            if let result = NSString(data: responseData, encoding: String.Encoding.utf8.rawValue) {
+                print("result = \(result)")
+            }
+            
             guard let res = self.parseResult(responseData) else {
                 return callback(nil)
             }


### PR DESCRIPTION
![error](https://user-images.githubusercontent.com/8379901/31042462-3cb9dc30-a56e-11e7-8c54-9f253f0d8acd.png)
我人在菲律賓，這這邊網速比較慢 所以剛好有測試到下面的問題
1. 當我在使用 異步請求的時候，如果沒有拿到 data 的時候沒有任何的 callback  回來。
```swift
 HTTPDNS.sharedInstance.getRecord("apple.com", callback: { (result) -> Void in
            print("Async QQ.com ", result ?? "Faild")
        })
```
2. 然後上面是我  crush 的圖片，幫你把 print 移到下面。
