### PR TITLE
移除 異步請求方法 裡面的 同步請求方法

### DIFF
--- a/HTTPDNS/HTTPDNS.swift
+++ b/HTTPDNS/HTTPDNS.swift
@@ -117,7 +117,7 @@ open class HTTPDNS {
         self.cache.removeAll()
     }
     
-    func setCache(_ domain: String, record: DNSRecord) -> HTTPDNSResult? {
+    func setCache(_ domain: String, record: DNSRecord?) -> HTTPDNSResult? {
         guard let _record = record else { return nil }
         let timeout = Date().timeIntervalSince1970 + Double(_record.ttl) * 1000
         var res = HTTPDNSResult.init(ip: _record.ip, ips: _record.ips, timeout: timeout, cached: true)

--- a/HTTPDNS/HTTPDNS.swift
+++ b/HTTPDNS/HTTPDNS.swift
@@ -85,6 +85,11 @@ open class HTTPDNS {
             return callback(res)
         }
         DNS.requsetRecord(domain, callback: { (res) -> Void in
+            
+            guard let _ = res else {
+                return callback(nil)
+            }
+            
             guard let res = self.DNS.requsetRecordSync(domain) else {
                 return callback(nil)
             }

--- a/HTTPDNS/HTTPDNS.swift
+++ b/HTTPDNS/HTTPDNS.swift
@@ -85,15 +85,11 @@ open class HTTPDNS {
             return callback(res)
         }
         DNS.requsetRecord(domain, callback: { (res) -> Void in
-            
-            guard let _ = res else {
+            if let res = res {
+                callback(self.setCache(domain, record: res))
+            } else {
                 return callback(nil)
             }
-            
-            guard let res = self.DNS.requsetRecordSync(domain) else {
-                return callback(nil)
-            }
-            callback(self.setCache(domain, record: res))
         })
     }
     
@@ -121,9 +117,10 @@ open class HTTPDNS {
         self.cache.removeAll()
     }
     
-    func setCache(_ domain: String, record: DNSRecord) -> HTTPDNSResult {
-        let timeout = Date().timeIntervalSince1970 +  Double(record.ttl) * 1000
-        var res = HTTPDNSResult.init(ip: record.ip, ips: record.ips, timeout: timeout, cached: true)
+    func setCache(_ domain: String, record: DNSRecord) -> HTTPDNSResult? {
+        guard let _record = record else { return nil }
+        let timeout = Date().timeIntervalSince1970 + Double(_record.ttl) * 1000
+        var res = HTTPDNSResult.init(ip: _record.ip, ips: _record.ips, timeout: timeout, cached: true)
         self.cache.updateValue(res, forKey:domain)
         res.cached = false
         return res

--- a/HTTPDNSTests/HTTPDNSTest.swift
+++ b/HTTPDNSTests/HTTPDNSTest.swift
@@ -36,7 +36,7 @@ class HTTPDNSTest: XCTestCase {
         let rec3 = client.getCacheResult(domain)
         XCTAssertNotNil(rec3)
         XCTAssertEqual(rec3?.ip, record.ip)
-        XCTAssertEqual(rec3?.ip, rec2.ip)
+        XCTAssertEqual(rec3?.ip, rec2?.ip)
         XCTAssertEqual(rec3?.cached, true)
         
         client.cleanCache()


### PR DESCRIPTION
Remove requsetRecordSync inside getRecord
這邊網路在使用 dnsPod 有點慢，所以剛好看到。
修正 UnitTest 